### PR TITLE
Feature/user address create

### DIFF
--- a/src/main/java/com/driven/dm/global/entity/Address.java
+++ b/src/main/java/com/driven/dm/global/entity/Address.java
@@ -2,9 +2,11 @@ package com.driven.dm.global.entity;
 
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
+@NoArgsConstructor
 public class Address {
     private String zipCode;
     private String primaryAddress;

--- a/src/main/java/com/driven/dm/global/entity/Address.java
+++ b/src/main/java/com/driven/dm/global/entity/Address.java
@@ -1,0 +1,22 @@
+package com.driven.dm.global.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Getter
+@Embeddable
+public class Address {
+    private String zipCode;
+    private String primaryAddress;
+    private String detailAddress;
+
+    public Address(String zipCode, String primaryAddress, String detailAddress) {
+        this.zipCode = zipCode;
+        this.primaryAddress = primaryAddress;
+        this.detailAddress = detailAddress;
+    }
+
+    public static Address create(String zipCode, String primaryAddress, String detailAddress) {
+        return new Address(zipCode, primaryAddress, detailAddress);
+    }
+}

--- a/src/main/java/com/driven/dm/user/application/exception/UserErrorCode.java
+++ b/src/main/java/com/driven/dm/user/application/exception/UserErrorCode.java
@@ -10,7 +10,10 @@ public enum UserErrorCode implements ErrorCode {
     USER_UNAUTHORIZED("USER000", "인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
     USER_NOT_FOUND("USER001", "해당 고객을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     DUPLICATE_USER_NAME("USER002", "이미 사용 중인 ID 입니다.", HttpStatus.CONFLICT),
-    DUPLICATE_NICK_NAME("USER003", "이미 사용 중인 닉네임입니다." , HttpStatus.CONFLICT);
+    DUPLICATE_NICK_NAME("USER003", "이미 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
+    MAX_ADDRESS_REACHED("USER004", "주소는 최대 10개까지 등록가능합니다.", HttpStatus.CONFLICT)
+    ;
+
 
     private final String code;
     private final String message;

--- a/src/main/java/com/driven/dm/user/application/service/UserAddressService.java
+++ b/src/main/java/com/driven/dm/user/application/service/UserAddressService.java
@@ -1,0 +1,49 @@
+package com.driven.dm.user.application.service;
+
+import com.driven.dm.global.entity.Address;
+import com.driven.dm.global.exception.AppException;
+import com.driven.dm.user.application.exception.UserErrorCode;
+import com.driven.dm.user.domain.entity.User;
+import com.driven.dm.user.domain.entity.UserAddress;
+import com.driven.dm.user.infrastructure.repository.UserAddressRepository;
+import com.driven.dm.user.infrastructure.repository.UserRepository;
+import com.driven.dm.user.presentation.controller.dto.request.UserAddressCreateRequest;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserAddressService {
+
+    private final UserRepository userRepository;
+    private final UserAddressRepository userAddressRepository;
+
+    private final static int MAX_USER_ADDRESS_COUNT = 10;
+
+    public UUID createUserAddress(UUID userId, UserAddressCreateRequest request) {
+        assertUserAddressLimitNotExceeded(userId);
+
+        User user = userRepository.findById(userId).orElseThrow(() -> {
+            throw AppException.of(UserErrorCode.USER_NOT_FOUND);
+        });
+
+        UserAddress userAddress = UserAddress.createDefault(
+            user,
+            Address.create(
+                request.zipCode(),
+                request.primaryAddress(),
+                request.detailAddress()
+            )
+        );
+        userAddressRepository.save(userAddress);
+        return userAddress.getId();
+    }
+
+    private void assertUserAddressLimitNotExceeded(UUID userId) {
+        long count = userAddressRepository.countByUser_IdAndDeletedAtIsNull(userId);
+        if (count >= MAX_USER_ADDRESS_COUNT) {
+            throw new AppException(UserErrorCode.MAX_ADDRESS_REACHED);
+        }
+    }
+}

--- a/src/main/java/com/driven/dm/user/application/service/UserAddressService.java
+++ b/src/main/java/com/driven/dm/user/application/service/UserAddressService.java
@@ -22,11 +22,13 @@ public class UserAddressService {
     private final static int MAX_USER_ADDRESS_COUNT = 10;
 
     public UUID createUserAddress(UUID userId, UserAddressCreateRequest request) {
-        assertUserAddressLimitNotExceeded(userId);
-
         User user = userRepository.findById(userId).orElseThrow(() -> {
             throw AppException.of(UserErrorCode.USER_NOT_FOUND);
         });
+
+        assertUserAddressLimitNotExceeded(userId);
+
+        userAddressRepository.clearDefaultByUserId(userId);
 
         UserAddress userAddress = UserAddress.createDefault(
             user,
@@ -36,6 +38,7 @@ public class UserAddressService {
                 request.detailAddress()
             )
         );
+
         userAddressRepository.save(userAddress);
         return userAddress.getId();
     }

--- a/src/main/java/com/driven/dm/user/domain/entity/UserAddress.java
+++ b/src/main/java/com/driven/dm/user/domain/entity/UserAddress.java
@@ -1,0 +1,51 @@
+package com.driven.dm.user.domain.entity;
+
+import com.driven.dm.global.entity.Address;
+import com.driven.dm.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@ToString
+@Table(name = "p_user_address")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserAddress extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Embedded
+    private Address address;
+
+    @Column(nullable = false)
+    private boolean isDefault;
+
+    private UserAddress(User user, Address address, boolean isDefault) {
+        this.user = user;
+        this.address = address;
+        this.isDefault = isDefault;
+    }
+
+    public static UserAddress createDefault(User user, Address address) {
+        return new UserAddress(user, address, true);
+    }
+}

--- a/src/main/java/com/driven/dm/user/infrastructure/repository/UserAddressRepository.java
+++ b/src/main/java/com/driven/dm/user/infrastructure/repository/UserAddressRepository.java
@@ -3,9 +3,21 @@ package com.driven.dm.user.infrastructure.repository;
 import com.driven.dm.user.domain.entity.UserAddress;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserAddressRepository extends JpaRepository<UserAddress, UUID> {
 
     long countByUser_IdAndDeletedAtIsNull(UUID userId);
 
+    @Query("""
+      update UserAddress ua
+         set ua.isDefault = false
+       where ua.user.id = :userId
+         and ua.isDefault = true
+         and ua.deletedAt is null
+    """)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    int clearDefaultByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/driven/dm/user/infrastructure/repository/UserAddressRepository.java
+++ b/src/main/java/com/driven/dm/user/infrastructure/repository/UserAddressRepository.java
@@ -1,0 +1,11 @@
+package com.driven.dm.user.infrastructure.repository;
+
+import com.driven.dm.user.domain.entity.UserAddress;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAddressRepository extends JpaRepository<UserAddress, UUID> {
+
+    long countByUser_IdAndDeletedAtIsNull(UUID userId);
+
+}

--- a/src/main/java/com/driven/dm/user/presentation/controller/UserAddressController.java
+++ b/src/main/java/com/driven/dm/user/presentation/controller/UserAddressController.java
@@ -1,0 +1,30 @@
+package com.driven.dm.user.presentation.controller;
+
+import com.driven.dm.global.config.security.SecurityUser;
+import com.driven.dm.user.application.service.UserAddressService;
+import com.driven.dm.user.presentation.controller.dto.request.UserAddressCreateRequest;
+import com.driven.dm.user.presentation.controller.dto.response.UserAddressCreateResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class
+UserAddressController {
+
+    private final UserAddressService userAddressService;
+    @PostMapping("/api/v1/users/me/addresses")
+    public ResponseEntity<UserAddressCreateResponse> createUserAddress(
+        @RequestBody @Valid UserAddressCreateRequest request,
+        @AuthenticationPrincipal SecurityUser securityUser
+    ) {
+        UUID userAddressId = userAddressService.createUserAddress(securityUser.getId(), request);
+        return ResponseEntity.ok().body(UserAddressCreateResponse.of(userAddressId));
+    }
+}

--- a/src/main/java/com/driven/dm/user/presentation/controller/dto/request/UserAddressCreateRequest.java
+++ b/src/main/java/com/driven/dm/user/presentation/controller/dto/request/UserAddressCreateRequest.java
@@ -1,0 +1,9 @@
+package com.driven.dm.user.presentation.controller.dto.request;
+
+public record UserAddressCreateRequest(
+    String zipCode,
+    String primaryAddress,
+    String detailAddress
+) {
+
+}

--- a/src/main/java/com/driven/dm/user/presentation/controller/dto/response/UserAddressCreateResponse.java
+++ b/src/main/java/com/driven/dm/user/presentation/controller/dto/response/UserAddressCreateResponse.java
@@ -1,0 +1,12 @@
+package com.driven.dm.user.presentation.controller.dto.response;
+
+
+import java.util.UUID;
+
+public record UserAddressCreateResponse(
+    UUID userAddressId
+) {
+    public static UserAddressCreateResponse of(UUID id) {
+        return new UserAddressCreateResponse(id);
+    }
+}

--- a/src/main/java/com/driven/dm/user/presentation/controller/dto/response/UserAddressResponse.java
+++ b/src/main/java/com/driven/dm/user/presentation/controller/dto/response/UserAddressResponse.java
@@ -1,0 +1,5 @@
+package com.driven.dm.user.presentation.controller.dto.response;
+
+public record UserAddressResponse() {
+
+}

--- a/src/main/java/com/driven/dm/user/presentation/dto/request/UserAddressCreateRequest.java
+++ b/src/main/java/com/driven/dm/user/presentation/dto/request/UserAddressCreateRequest.java
@@ -1,8 +1,19 @@
 package com.driven.dm.user.presentation.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
 public record UserAddressCreateRequest(
+    @NotBlank(message = "우편번호는 필수입니다.")
+    @Pattern(regexp = "\\d{5}", message = "우편번호는 숫자 5자리여야 합니다.")
     String zipCode,
+
+    @NotBlank(message = "기본 주소는 필수입니다.")
+    @Size(max = 255, message = "기본 주소는 255자 이하여야 합니다.")
     String primaryAddress,
+
+    @Size(max = 255, message = "상세 주소는 255자 이하여야 합니다.")
     String detailAddress
 ) {
 

--- a/src/test/java/com/driven/dm/user/application/service/UserAddressServiceTest.java
+++ b/src/test/java/com/driven/dm/user/application/service/UserAddressServiceTest.java
@@ -1,0 +1,97 @@
+package com.driven.dm.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import com.driven.dm.global.exception.AppException;
+import com.driven.dm.user.application.exception.UserErrorCode;
+import com.driven.dm.user.domain.entity.User;
+import com.driven.dm.user.domain.entity.UserAddress;
+import com.driven.dm.user.infrastructure.repository.UserAddressRepository;
+import com.driven.dm.user.infrastructure.repository.UserRepository;
+import com.driven.dm.user.presentation.controller.dto.request.UserAddressCreateRequest;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserAddressServiceTest {
+
+    @InjectMocks
+    UserAddressService userAddressService;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    UserAddressRepository userAddressRepository;
+
+    @Test
+    @DisplayName("유저가 주소 생성 요청을 보내면 기본주소로 저장된다")
+    void createUserAddressTest() {
+        UUID userId = UUID.randomUUID();
+        String zipCode = "00000";
+        String primaryAddress = "서울특별시 동작구";
+        String detailAddress = "우리집";
+
+        UserAddressCreateRequest request = new UserAddressCreateRequest(zipCode,
+            primaryAddress, detailAddress);
+
+        User mockUser = mock(User.class);
+        given(mockUser.getId()).willReturn(userId);
+
+        UserAddress mockUserAddress = mock(UserAddress.class);
+        ArgumentCaptor<UserAddress> userAddressCaptor = ArgumentCaptor.forClass(UserAddress.class);
+        given(userAddressRepository.countByUser_IdAndDeletedAtIsNull(userId)).willReturn(0L);
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(userAddressRepository.save(userAddressCaptor.capture())).willReturn(mockUserAddress);
+
+        UUID result = userAddressService.createUserAddress(userId, request);
+
+        UserAddress savedUserAddress = userAddressCaptor.getValue();
+
+        assertThat(result).isEqualTo(savedUserAddress.getId());
+        assertThat(savedUserAddress.getUser().getId()).isEqualTo(userId);
+        assertThat(savedUserAddress.getAddress().getZipCode()).isEqualTo(zipCode);
+        assertThat(savedUserAddress.getAddress().getPrimaryAddress()).isEqualTo(primaryAddress);
+        assertThat(savedUserAddress.getAddress().getDetailAddress()).isEqualTo(detailAddress);
+        assertThat(savedUserAddress.isDefault()).isTrue();
+
+        then(userAddressRepository).should().countByUser_IdAndDeletedAtIsNull(userId);
+        then(userRepository).should().findById(userId);
+        then(userAddressRepository).should(times(1)).save(any(UserAddress.class));
+    }
+
+    @Test
+    @DisplayName("주소가 10개 이상이면 추가 생성은 실패한다")
+    void shouldFailToCreate_whenHas10Addresses() {
+        UUID userId = UUID.randomUUID();
+        String zipCode = "00000";
+        String primaryAddress = "서울특별시 동작구";
+        String detailAddress = "우리집";
+
+        UserAddressCreateRequest request = new UserAddressCreateRequest(zipCode,
+            primaryAddress, detailAddress);
+
+        given(userAddressRepository.countByUser_IdAndDeletedAtIsNull(userId)).willReturn(10L);
+
+        assertThatThrownBy(() -> {
+            userAddressService.createUserAddress(userId, request);
+        }).isInstanceOf(AppException.class)
+            .hasMessage(UserErrorCode.MAX_ADDRESS_REACHED.getMessage());
+
+        then(userAddressRepository).should(never()).save(any(UserAddress.class));
+    }
+}

--- a/src/test/java/com/driven/dm/user/application/service/UserAddressServiceTest.java
+++ b/src/test/java/com/driven/dm/user/application/service/UserAddressServiceTest.java
@@ -85,6 +85,9 @@ class UserAddressServiceTest {
         UserAddressCreateRequest request = new UserAddressCreateRequest(zipCode,
             primaryAddress, detailAddress);
 
+        User mockUser = mock(User.class);
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+
         given(userAddressRepository.countByUser_IdAndDeletedAtIsNull(userId)).willReturn(10L);
 
         assertThatThrownBy(() -> {


### PR DESCRIPTION
## 📌 개요
유저 주소 등록 기능 추가
단위 테스트 포함
주소 최대 보유 개수 정책 적용 (최대 10개)

## ✅ 작업 사항
- 유저 주소 추가 API
- 단위 테스트
- 주소가 10개 이상일 때 등록 실패

## 🔍 리뷰 요청 포인트
주소 최대 개수 검증 위치/방법 적절성, 예외 코드/응답 포맷 일관성

## 💬 기타 사항


---
