### PR TITLE
Feat/shopaddress create 18

### DIFF
--- a/src/main/java/com/driven/dm/shop/application/config/RestClientConfig.java
+++ b/src/main/java/com/driven/dm/shop/application/config/RestClientConfig.java
@@ -1,0 +1,18 @@
+package com.driven.dm.shop.application.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient kakaoRestClient(RestClient.Builder builder) {
+
+        return builder
+            .baseUrl("https://dapi.kakao.com")
+            .build();
+    }
+
+}

--- a/src/main/java/com/driven/dm/shop/application/exception/ShopErrorCode.java
+++ b/src/main/java/com/driven/dm/shop/application/exception/ShopErrorCode.java
@@ -8,7 +8,10 @@ import org.springframework.http.HttpStatus;
 public enum ShopErrorCode implements ErrorCode {
 
     SHOP_NOT_FOUND("SHOP001","해당 가게를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    SHOP_NOT_OWNER("SHOP002","가게 관리자만 등록이 가능합니다.", HttpStatus.FORBIDDEN);
+    SHOP_NOT_OWNER("SHOP002","가게 관리자만 등록이 가능합니다.", HttpStatus.FORBIDDEN),
+    ADDRESS_NO_SUCH("SHOP005", "주소 검색 결과가 없습니다.", HttpStatus.BAD_REQUEST),
+    ADDRESS_NO_STATE("SHOP006", "유효한 주소 필드가 없습니다.", HttpStatus.BAD_REQUEST),
+    ADDRESS_DUPLICATE("SHOP007", "가게 주소가 이미 등록되어있습니다.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/driven/dm/shop/application/service/KakaoLocalClient.java
+++ b/src/main/java/com/driven/dm/shop/application/service/KakaoLocalClient.java
@@ -1,0 +1,35 @@
+package com.driven.dm.shop.application.service;
+
+import com.driven.dm.shop.presentation.dto.response.KakaoAddressSearchResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoLocalClient {
+
+    private final RestClient restClient;
+
+    @Value("${kakao.local.rest-api-key}")
+    private String apiKey;
+
+    public Optional<KakaoAddressSearchResponse.Document> searchFirst(String query){
+        KakaoAddressSearchResponse body = restClient.get()
+            .uri(uriBuilder -> uriBuilder
+                .path("/v2/local/search/address.json")
+                .queryParam("query", query)
+                .build())
+            .header("Authorization", "KakaoAK " + apiKey)
+            .retrieve()
+            .body(KakaoAddressSearchResponse.class);
+
+        if(body == null || body.getDocuments() == null || body.getDocuments().isEmpty()){
+            return Optional.empty();
+        }
+
+        return Optional.of(body.getDocuments().get(0));
+    }
+}

--- a/src/main/java/com/driven/dm/shop/application/service/ShopAddressService.java
+++ b/src/main/java/com/driven/dm/shop/application/service/ShopAddressService.java
@@ -1,0 +1,96 @@
+package com.driven.dm.shop.application.service;
+
+import com.driven.dm.global.config.security.SecurityUser;
+import com.driven.dm.global.exception.AppException;
+import com.driven.dm.shop.application.exception.ShopErrorCode;
+import com.driven.dm.shop.domain.entity.Shop;
+import com.driven.dm.shop.domain.entity.ShopAddress;
+import com.driven.dm.shop.domain.repository.ShopAddressRepository;
+import com.driven.dm.shop.domain.repository.ShopRepository;
+import com.driven.dm.shop.presentation.dto.request.AddressCreateRequest;
+import com.driven.dm.shop.presentation.dto.response.AddressResponse;
+import com.driven.dm.user.application.exception.UserErrorCode;
+import com.driven.dm.user.domain.entity.User;
+import com.driven.dm.user.infrastructure.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ShopAddressService {
+
+    private final ShopRepository shopRepository;
+    private final UserRepository userRepository;
+    private final KakaoLocalClient kakaoLocalClient;
+    private final ShopAddressRepository shopAddressRepository;
+
+    @Transactional
+    public AddressResponse create(UUID id, SecurityUser securityUser ,AddressCreateRequest req) {
+
+        Shop shop = shopRepository.selectShop(id);
+        if(shop == null){
+            throw new AppException(ShopErrorCode.SHOP_NOT_FOUND);
+        }
+
+        User user = userRepository.findById(securityUser.getId()).orElseThrow(
+            () -> new AppException(UserErrorCode.USER_NOT_FOUND)
+        );
+
+        if(shop.getOwner().getId() != user.getId()){
+            throw new AppException(ShopErrorCode.SHOP_NOT_OWNER);
+        }
+
+        if (shop.getAddress() != null) {
+            throw new AppException(ShopErrorCode.ADDRESS_DUPLICATE);
+        }
+
+        // 카카오 API 호출
+        var docOpt = kakaoLocalClient.searchFirst(req.getQuery());
+        var doc = docOpt.orElseThrow(
+            () -> new AppException(ShopErrorCode.ADDRESS_NO_SUCH)
+        );
+
+        // 전체주소 & 좌표 추출
+        String fullAddress;
+        String xStr;
+        String yStr;
+        String region_1depth_name;
+        String region_2depth_name;
+        String region_3depth_name;
+        String h_code;
+
+        if (doc.getAddress() != null){
+            fullAddress = doc.getAddress().getAddress_name();
+            xStr = doc.getAddress().getX();
+            yStr = doc.getAddress().getY();
+            region_1depth_name = doc.getAddress().getRegion_1depth_name();
+            region_2depth_name = doc.getAddress().getRegion_2depth_name();
+            region_3depth_name = doc.getAddress().getRegion_3depth_name();
+            h_code = doc.getAddress().getH_code();
+        } else {
+            throw new AppException(ShopErrorCode.ADDRESS_NO_STATE);
+        }
+
+        Double longitude = Double.parseDouble(xStr);
+        Double latitude = Double.parseDouble(yStr);
+
+        if(longitude == null || latitude == null){
+            throw new AppException(ShopErrorCode.ADDRESS_NO_STATE);
+        }
+
+        ShopAddress shopAddress = ShopAddress.of(shop, fullAddress, latitude, longitude, region_1depth_name, region_2depth_name, region_3depth_name, h_code);
+        ShopAddress createAddress = shopAddressRepository.createShopAddress(shopAddress);
+
+        return AddressResponse.builder()
+            .id(createAddress.getId())
+            .fullAddress(createAddress.getFullAddress())
+
+            .latitude(createAddress.getLatitude())
+            .longitude(createAddress.getLongitude())
+            .source("kakao")
+            .build();
+    }
+
+}

--- a/src/main/java/com/driven/dm/shop/application/service/ShopAddressService.java
+++ b/src/main/java/com/driven/dm/shop/application/service/ShopAddressService.java
@@ -12,10 +12,10 @@ import com.driven.dm.shop.presentation.dto.response.AddressResponse;
 import com.driven.dm.user.application.exception.UserErrorCode;
 import com.driven.dm.user.domain.entity.User;
 import com.driven.dm.user.infrastructure.repository.UserRepository;
-import jakarta.transaction.Transactional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -38,7 +38,7 @@ public class ShopAddressService {
             () -> new AppException(UserErrorCode.USER_NOT_FOUND)
         );
 
-        if(shop.getOwner().getId() != user.getId()){
+        if(shop.getOwner().getId().equals(user.getId())) {
             throw new AppException(ShopErrorCode.SHOP_NOT_OWNER);
         }
 

--- a/src/main/java/com/driven/dm/shop/application/service/ShopService.java
+++ b/src/main/java/com/driven/dm/shop/application/service/ShopService.java
@@ -121,7 +121,7 @@ public class ShopService {
             // 사장이 아님
         }
 
-        if(!(user.get().getId() == shop.getId())) {
+        if(!(user.get().getId().equals(shop.getOwner().getId()))) {
             // 본인 가게가 아님
         }
 

--- a/src/main/java/com/driven/dm/shop/application/service/ShopService.java
+++ b/src/main/java/com/driven/dm/shop/application/service/ShopService.java
@@ -12,13 +12,13 @@ import com.driven.dm.shop.presentation.dto.response.ShopListResponseDto;
 import com.driven.dm.shop.presentation.dto.response.ShopResponseDto;
 import com.driven.dm.user.domain.entity.User;
 import com.driven.dm.user.infrastructure.repository.UserRepository;
-import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -63,6 +63,7 @@ public class ShopService {
                     .shopName(openShop.getShopName())
                     .description(openShop.getDescription())
                     .avgRating(openShop.getAvgRating())
+                    .address(openShop.getAddress())
                     .build();
                 shopListResponseDto.add(shopListResponse);
             }
@@ -71,6 +72,7 @@ public class ShopService {
         return shopListResponseDto;
     }
 
+    @Transactional(readOnly = true)
     public ShopResponseDto getShop(UUID id) {
         Shop selectShop = shopRepository.selectShop(id);
 

--- a/src/main/java/com/driven/dm/shop/domain/entity/Shop.java
+++ b/src/main/java/com/driven/dm/shop/domain/entity/Shop.java
@@ -4,6 +4,7 @@ import com.driven.dm.global.entity.BaseEntity;
 import com.driven.dm.shop.presentation.dto.request.ShopDto;
 import com.driven.dm.shop.presentation.dto.request.ShopUpdateDto;
 import com.driven.dm.user.domain.entity.User;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,7 +43,6 @@ public class Shop extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User owner;
 
-
     @Column(name = "shop_name", nullable = false)
     private String shopName;
 
@@ -56,7 +56,8 @@ public class Shop extends BaseEntity {
     @Column(name = "shop_status")
     private ShopStatus status;
 
-    @OneToOne(mappedBy = "shop", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "shop", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @JsonManagedReference
     private ShopAddress address;
 
     public static Shop of(ShopDto shopDto){

--- a/src/main/java/com/driven/dm/shop/domain/entity/ShopAddress.java
+++ b/src/main/java/com/driven/dm/shop/domain/entity/ShopAddress.java
@@ -1,5 +1,7 @@
 package com.driven.dm.shop.domain.entity;
 
+import com.driven.dm.shop.presentation.dto.request.AddressCreateRequest;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -28,11 +30,50 @@ public class ShopAddress {
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "shop_id", nullable = false)
+    @JsonBackReference
     private Shop shop;
 
-    @Column(name = "primary_address")
-    private String primaryAddress;
+    @Column(name = "full_address", nullable = false, length = 300)
+    private String fullAddress;
 
-    @Column(name = "detail_address")
-    private String detailAddress;
+    @Column(name = "x")
+    private Double longitude;
+
+    @Column(name = "y")
+    private Double latitude;
+
+    @Column(name = "province_name")
+    private String region_1depth;
+
+    @Column(name = "city_name")
+    private String region_2depth;
+
+    @Column(name = "district_name")
+    private String region_3depth;
+
+    @Column(name = "administrative_code")
+    private String h_code;
+
+    public static ShopAddress of(
+            Shop shop,
+            String fullAddress,
+            Double longitude,
+            Double latitude,
+            String region_1depth_name,
+            String region_2depth_name,
+            String region_3depth_name,
+            String h_code) {
+
+        ShopAddress shopAddress = new ShopAddress();
+        shopAddress.shop = shop;
+        shopAddress.fullAddress = fullAddress;
+        shopAddress.region_1depth = region_1depth_name;
+        shopAddress.region_2depth = region_2depth_name;
+        shopAddress.region_3depth = region_3depth_name;
+        shopAddress.h_code = h_code;
+        shopAddress.longitude = longitude;
+        shopAddress.latitude = latitude;
+        return shopAddress;
+    }
+
 }

--- a/src/main/java/com/driven/dm/shop/domain/repository/ShopAddressRepository.java
+++ b/src/main/java/com/driven/dm/shop/domain/repository/ShopAddressRepository.java
@@ -1,0 +1,8 @@
+package com.driven.dm.shop.domain.repository;
+
+import com.driven.dm.shop.domain.entity.ShopAddress;
+
+public interface ShopAddressRepository {
+
+    ShopAddress createShopAddress(ShopAddress shopAddress);
+}

--- a/src/main/java/com/driven/dm/shop/infrastructure/repository/ShopAddressJpaRepository.java
+++ b/src/main/java/com/driven/dm/shop/infrastructure/repository/ShopAddressJpaRepository.java
@@ -1,0 +1,8 @@
+package com.driven.dm.shop.infrastructure.repository;
+
+import com.driven.dm.shop.domain.entity.ShopAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopAddressJpaRepository extends JpaRepository<ShopAddress, Long> {
+
+}

--- a/src/main/java/com/driven/dm/shop/infrastructure/repository/ShopAddressRepositoryImpl.java
+++ b/src/main/java/com/driven/dm/shop/infrastructure/repository/ShopAddressRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.driven.dm.shop.infrastructure.repository;
+
+import com.driven.dm.shop.domain.entity.ShopAddress;
+import com.driven.dm.shop.domain.repository.ShopAddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ShopAddressRepositoryImpl implements ShopAddressRepository {
+
+    private final ShopAddressJpaRepository shopAddressJpaRepository;
+
+    @Override
+    public ShopAddress createShopAddress(ShopAddress shopAddress) {
+
+        return shopAddressJpaRepository.save(shopAddress);
+    }
+}

--- a/src/main/java/com/driven/dm/shop/presentation/controller/ShopController.java
+++ b/src/main/java/com/driven/dm/shop/presentation/controller/ShopController.java
@@ -1,11 +1,15 @@
 package com.driven.dm.shop.presentation.controller;
 
 import com.driven.dm.global.config.security.SecurityUser;
+import com.driven.dm.shop.application.service.ShopAddressService;
 import com.driven.dm.shop.application.service.ShopService;
+import com.driven.dm.shop.presentation.dto.request.AddressCreateRequest;
 import com.driven.dm.shop.presentation.dto.request.ShopDto;
 import com.driven.dm.shop.presentation.dto.request.ShopUpdateDto;
+import com.driven.dm.shop.presentation.dto.response.AddressResponse;
 import com.driven.dm.shop.presentation.dto.response.ShopListResponseDto;
 import com.driven.dm.shop.presentation.dto.response.ShopResponseDto;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ShopController {
 
     private final ShopService shopService;
+    private final ShopAddressService shopAddressService;
 
     @PostMapping
     public ResponseEntity<ShopResponseDto> createShop(
@@ -71,4 +76,16 @@ public class ShopController {
 
         return ResponseEntity.ok().body(null);
     }
+
+    @PostMapping("/{id}/address")
+    public ResponseEntity<AddressResponse> create(
+        @PathVariable UUID id,
+        @AuthenticationPrincipal SecurityUser securityUser,
+        @Valid @RequestBody AddressCreateRequest addressCreateRequest
+    ){
+        AddressResponse addressResponse = shopAddressService.create(id, securityUser, addressCreateRequest);
+
+        return ResponseEntity.ok().body(addressResponse);
+    }
+
 }

--- a/src/main/java/com/driven/dm/shop/presentation/dto/request/AddressCreateRequest.java
+++ b/src/main/java/com/driven/dm/shop/presentation/dto/request/AddressCreateRequest.java
@@ -1,0 +1,13 @@
+package com.driven.dm.shop.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class AddressCreateRequest {
+
+    @NotBlank
+    private String query;
+
+}

--- a/src/main/java/com/driven/dm/shop/presentation/dto/response/AddressResponse.java
+++ b/src/main/java/com/driven/dm/shop/presentation/dto/response/AddressResponse.java
@@ -1,0 +1,21 @@
+package com.driven.dm.shop.presentation.dto.response;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AddressResponse {
+
+    private UUID id;
+    private String fullAddress;
+    private String region_1depth_name;
+    private String region_2depth_name;
+    private String region_3depth_name;
+    private String h_code;
+    private Double latitude;
+    private Double longitude;
+    private String source;
+
+}

--- a/src/main/java/com/driven/dm/shop/presentation/dto/response/KakaoAddressSearchResponse.java
+++ b/src/main/java/com/driven/dm/shop/presentation/dto/response/KakaoAddressSearchResponse.java
@@ -1,0 +1,27 @@
+package com.driven.dm.shop.presentation.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class KakaoAddressSearchResponse {
+
+    private List<Document> documents;
+
+    @Getter @Setter
+    public static class Document{
+        private Address address;
+    }
+
+    @Getter @Setter
+    public static class Address{
+        private String address_name;
+        private String region_1depth_name;
+        private String region_2depth_name;
+        private String region_3depth_name;
+        private String h_code;
+        private String x;
+        private String y;
+    }
+}

--- a/src/main/java/com/driven/dm/shop/presentation/dto/response/ShopListResponseDto.java
+++ b/src/main/java/com/driven/dm/shop/presentation/dto/response/ShopListResponseDto.java
@@ -1,5 +1,7 @@
 package com.driven.dm.shop.presentation.dto.response;
 
+import com.driven.dm.shop.domain.entity.ShopAddress;
+import com.driven.dm.shop.presentation.dto.response.KakaoAddressSearchResponse.Address;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,5 +12,6 @@ public class ShopListResponseDto {
     private String shopName;
     private String description;
     private double avgRating;
+    private ShopAddress address;
 
 }

--- a/src/main/java/com/driven/dm/shop/presentation/dto/response/ShopResponseDto.java
+++ b/src/main/java/com/driven/dm/shop/presentation/dto/response/ShopResponseDto.java
@@ -21,7 +21,7 @@ public class ShopResponseDto {
 
     private ShopStatus shopStatus;
 
-    private ShopAddress address;
+    private String address;
 
     public static ShopResponseDto from(Shop shop) {
 
@@ -31,7 +31,7 @@ public class ShopResponseDto {
             .description(shop.getDescription())
             .avgRating(shop.getAvgRating())
             .shopStatus(shop.getStatus())
-            .address(shop.getAddress())
+            .address(shop.getAddress().getFullAddress())
             .build();
     }
 


### PR DESCRIPTION
## 📌 개요
카카오 API 이용하여 가게 주소 등록 기능 구현 완료 


## ✅ 작업 사항
- [ ] 카카오 API를 이용하여 가게 주소를 등록할 수 있다. 
- [ ] 카카오 API를 사용하는 것은 RestClient 사용했음 .
- [ ] 가게는 유저랑 다르게 하나의 가게 주소만 등록할 수 있다.
- [ ] 가게 주소 등록시 전체주소, 위도, 경도, 시/군/구 를 받아와서 저장할 수 있음. 

## 🔍 리뷰 요청 포인트


## 💬 기타 사항
- 관련 이슈: #18 

---
