### PR TITLE
feature: 테스트용 PG API 추가

### DIFF
--- a/src/main/java/com/driven/dm/payment/application/service/PaymentService.java
+++ b/src/main/java/com/driven/dm/payment/application/service/PaymentService.java
@@ -17,6 +17,7 @@ import com.driven.dm.payment.domain.repository.IdempotencyStore;
 import com.driven.dm.payment.domain.repository.PaymentRepository;
 import com.driven.dm.payment.presentation.request.PaymentCreateRequest;
 import com.driven.dm.payment.presentation.response.PaymentResponse;
+import com.driven.dm.payment.presentation.response.PaymentStatusResponse;
 import com.driven.dm.user.application.service.UserReader;
 import com.driven.dm.user.domain.entity.User;
 
@@ -71,5 +72,12 @@ public class PaymentService {
 		if (!Objects.equals(order.getTotalPrice(), request.getAmount())) {
 			throw new AppException(PaymentErrorCode.AMOUNT_MISMATCH);
 		}
+	}
+
+	public PaymentStatusResponse getPayment(UUID paymentId) {
+		Payment payment = paymentRepository.findById(paymentId)
+										   .orElseThrow(() -> new AppException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+		return PaymentStatusResponse.from(payment);
 	}
 }

--- a/src/main/java/com/driven/dm/payment/application/service/TestPgService.java
+++ b/src/main/java/com/driven/dm/payment/application/service/TestPgService.java
@@ -1,0 +1,44 @@
+package com.driven.dm.payment.application.service;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.driven.dm.global.exception.AppException;
+import com.driven.dm.order.application.exception.PaymentErrorCode;
+import com.driven.dm.payment.domain.entity.Payment;
+import com.driven.dm.payment.domain.entity.PaymentStatus;
+import com.driven.dm.payment.domain.repository.PaymentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TestPgService {
+
+	private final PaymentRepository paymentRepository;
+
+	// PAYMENT_PENDING 또는 PG_REQUESTED 상태일 때만 최종 결정을 허용
+	private static final Set<PaymentStatus> ALLOW_FROM =
+		EnumSet.of(PaymentStatus.PAYMENT_PENDING, PaymentStatus.PG_REQUESTED);
+
+	@Transactional
+	public Payment decide(UUID paymentId, String decision, String reason) {
+		Payment p = paymentRepository.findById(paymentId)
+									 .orElseThrow(() -> new AppException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+		// 이미 최종 상태면 그대로 반환
+		if (!ALLOW_FROM.contains(p.getStatus())) return p;
+
+		switch (decision) {
+			case "approve" -> p.approve(UUID.randomUUID().toString());
+			case "decline" -> p.decline(reason);
+			case "cancel"  -> p.cancel(reason);
+			default -> throw new IllegalArgumentException("unknown decision");
+		}
+		return p;
+	}
+}

--- a/src/main/java/com/driven/dm/payment/domain/entity/Payment.java
+++ b/src/main/java/com/driven/dm/payment/domain/entity/Payment.java
@@ -1,5 +1,6 @@
 package com.driven.dm.payment.domain.entity;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
 
@@ -60,11 +61,17 @@ public class Payment extends BaseEntity {
 	@Column(name = "idemKey")
 	private String idemKey;
 
-	@Column(name = "pgProvier")
+	@Column(name = "pgProvider")
 	private String pgProvider;
 
 	@Column(name = "transaction_id")
 	private String transactionId;
+
+	@Column(name = "failure_reason", length = 200)
+	private String failureReason;  // 실패/취소 사유(DECLINED/CANCELED 시)
+
+	@Column(name = "approved_at")
+	private LocalDateTime approvedAt;
 
 	@JdbcTypeCode(SqlTypes.JSON)
 	@Column(name = "details", columnDefinition = "jsonb", nullable = false)
@@ -75,12 +82,26 @@ public class Payment extends BaseEntity {
 		Payment payment = new Payment();
 		payment.user = loginUser;
 		payment.order = order;
-		payment.status = PaymentStatus.CREATED;
+		payment.status = PaymentStatus.PAYMENT_PENDING;
 		payment.method = request.getMethod();
 		payment.amount = request.getAmount();
 		payment.idemKey = idemKey;
 		payment.pgProvider = "inhouse-mock"; // 임시 제공자
 		payment.details = details;
 		return payment;
+	}
+
+	public void approve(String pgTid) {
+		this.status = PaymentStatus.PAYMENT_APPROVED;
+		this.transactionId = pgTid; // 테스트라서 null. 원래는 id값을 넣어줘야함.
+		this.approvedAt = LocalDateTime.now();
+	}
+	public void decline(String reason) {
+		this.status = PaymentStatus.PAYMENT_DECLINED;
+		this.failureReason = reason;
+	}
+	public void cancel(String reason) {
+		this.status = PaymentStatus.PAYMENT_CANCELED;
+		this.failureReason = reason;
 	}
 }

--- a/src/main/java/com/driven/dm/payment/domain/entity/PaymentStatus.java
+++ b/src/main/java/com/driven/dm/payment/domain/entity/PaymentStatus.java
@@ -1,9 +1,9 @@
 package com.driven.dm.payment.domain.entity;
 
 public enum PaymentStatus {
-    CREATED,
     PAYMENT_PENDING,
-    PAID,
-    PAYMENT_FAILED,
-    CANCELED
+	PG_REQUESTED,
+	PAYMENT_APPROVED,
+	PAYMENT_DECLINED,
+	PAYMENT_CANCELED
 }

--- a/src/main/java/com/driven/dm/payment/presentation/controller/PaymentController.java
+++ b/src/main/java/com/driven/dm/payment/presentation/controller/PaymentController.java
@@ -1,8 +1,12 @@
 package com.driven.dm.payment.presentation.controller;
 
+import java.util.UUID;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -12,6 +16,7 @@ import com.driven.dm.global.config.security.SecurityUser;
 import com.driven.dm.payment.application.service.PaymentService;
 import com.driven.dm.payment.presentation.request.PaymentCreateRequest;
 import com.driven.dm.payment.presentation.response.PaymentResponse;
+import com.driven.dm.payment.presentation.response.PaymentStatusResponse;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +37,12 @@ public class PaymentController {
 		) {
 		PaymentResponse response = paymentService.createPayment(request, securityUser, idemKey);
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	@GetMapping("/{paymentId}")
+	public ResponseEntity<PaymentStatusResponse> getPaymentStatus(@PathVariable UUID paymentId) {
+		PaymentStatusResponse response = paymentService.getPayment(paymentId);
+
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/driven/dm/payment/presentation/controller/TestPgController.java
+++ b/src/main/java/com/driven/dm/payment/presentation/controller/TestPgController.java
@@ -1,0 +1,34 @@
+package com.driven.dm.payment.presentation.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.driven.dm.payment.application.service.TestPgService;
+import com.driven.dm.payment.presentation.request.TestPgDecisionRequest;
+import com.driven.dm.payment.presentation.response.PaymentStatusResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/test-pg")
+@RequiredArgsConstructor
+public class TestPgController {
+
+	private final TestPgService testPgService;
+
+	@PostMapping("/decide")
+	public ResponseEntity<PaymentStatusResponse> decide(@RequestBody @Validated TestPgDecisionRequest req) {
+		var p = testPgService.decide(req.getPaymentId(), req.getDecision(), req.getReason());
+		return ResponseEntity.ok(
+			PaymentStatusResponse.builder()
+								 .paymentId(p.getId())
+								 .status(p.getStatus().name())
+								 .failureReason(p.getFailureReason())
+								 .build()
+		);
+	}
+}

--- a/src/main/java/com/driven/dm/payment/presentation/request/TestPgDecisionRequest.java
+++ b/src/main/java/com/driven/dm/payment/presentation/request/TestPgDecisionRequest.java
@@ -1,0 +1,24 @@
+package com.driven.dm.payment.presentation.request;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TestPgDecisionRequest {
+
+	@NotNull
+	private UUID paymentId;
+
+	// 승인 | 거절 | 취소
+	@NotNull
+	@Pattern(regexp = "approve|decline|cancel")
+	private String decision;
+
+	// 실패/취소 사유 (옵션)
+	private String reason;
+}

--- a/src/main/java/com/driven/dm/payment/presentation/response/PaymentResponse.java
+++ b/src/main/java/com/driven/dm/payment/presentation/response/PaymentResponse.java
@@ -30,7 +30,8 @@ public class PaymentResponse {
 	private String clientToken;
 
 	public static PaymentResponse from(Payment payment) {
-		if (payment == null) return null;
+		if (payment == null)
+			return null;
 
 		return PaymentResponse.builder()
 							  .paymentId(payment.getId())

--- a/src/main/java/com/driven/dm/payment/presentation/response/PaymentStatusResponse.java
+++ b/src/main/java/com/driven/dm/payment/presentation/response/PaymentStatusResponse.java
@@ -1,0 +1,14 @@
+package com.driven.dm.payment.presentation.response;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PaymentStatusResponse {
+	private UUID paymentId;
+	private String status;
+	private String failureReason;
+}

--- a/src/main/java/com/driven/dm/payment/presentation/response/PaymentStatusResponse.java
+++ b/src/main/java/com/driven/dm/payment/presentation/response/PaymentStatusResponse.java
@@ -2,6 +2,8 @@ package com.driven.dm.payment.presentation.response;
 
 import java.util.UUID;
 
+import com.driven.dm.payment.domain.entity.Payment;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,4 +13,17 @@ public class PaymentStatusResponse {
 	private UUID paymentId;
 	private String status;
 	private String failureReason;
+
+	public static PaymentStatusResponse from(Payment payment) {
+		if (payment == null) {
+			throw new NullPointerException("결제 정보가 null입니다.");
+		}
+
+		return PaymentStatusResponse.builder()
+									.paymentId(payment.getId())
+									.status(payment.getStatus() != null ? payment.getStatus().name() : null)
+									.failureReason(payment.getFailureReason()) // null 허용 (REJECTED 아닐 경우)
+									.build();
+	}
+
 }


### PR DESCRIPTION
## 📌 개요
테스트용 PG 승인/거절 처리 API 및 결제 상태 조회 API 추가

## ✅ 작업 사항
- `TestPgController` 추가 (`/api/v1/test-pg/decide`)
    - 결제 승인/거절 결정 처리
    - `PaymentStatusResponse` 응답 반환
- `PaymentController` 추가 (`/api/v1/payments/{paymentId}`)
    - 결제 상태 단건 조회 API 구현
- `PaymentStatusResponse.from()` 메서드 구현 (null 안전 처리 포함)

## 🔍 리뷰 요청 포인트

## 💬 기타 사항
결제 api 명세서 수정 필요

---
